### PR TITLE
Modernize pycon.lt deployments

### DIFF
--- a/websites/pycon.lt/ansible.cfg
+++ b/websites/pycon.lt/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+inventory = inventory.cfg

--- a/websites/pycon.lt/deploy.yml
+++ b/websites/pycon.lt/deploy.yml
@@ -6,15 +6,16 @@
   tasks:
 
   - name: apt packages
-    apt: pkg={{ item }} state=latest
-    with_items:
-    - apache2
+    apt: pkg={{ items }} state=latest
+    vars:
+      items:
+      - apache2
 
-    # Lets encrypt
-    - libaugeas0
-    - libssl-dev
-    - libffi-dev
-    - ca-certificates
+      # Let's encrypt
+      - libaugeas0
+      - libssl-dev
+      - libffi-dev
+      - ca-certificates
 
   # Apache
 
@@ -41,14 +42,21 @@
   # Let's Encrypt
 
   - name: install letsencrypt
-    pip: name={{ item }} virtualenv=/opt/letsencrypt state=latest
-    with_items:
-    - letsencrypt
-    - letsencrypt-apache
+    pip:
+      name: "{{ items }}"
+      virtualenv: /opt/letsencrypt
+      # the pip module doesn't know how to check for available updates in check
+      # mode, so it always returns a useless "changed" result, so let's make it
+      # not do that by using state=present for --check runs
+      state: "{{ 'present' if ansible_check_mode else 'latest'}}"
+    vars:
+      items:
+      - certbot
+      - certbot-apache
 
   - name: let's encrypt!
     command: >
-      /opt/letsencrypt/bin/letsencrypt certonly
+      /opt/letsencrypt/bin/certbot certonly
         --text
         --agree-tos
         --non-interactive
@@ -72,9 +80,6 @@
 
 
   handlers:
-
-  - name: reload source code
-    command: touch --no-create {{ path }}/bin/django.wsgi
 
   - name: reload apache
     service: name=apache2 state=reloaded


### PR DESCRIPTION
- install certbot and certbot-apache instead of letsencrypt and
  letsencrypt-apache (they're the same thing, renamed in 2016):
  https://community.letsencrypt.org/t/new-name-certbot-for-python-lets-encrypt-client/15688

- using with_items to install multiple items for apt/pip modules was
  deprecated in Ansible 2.7:
  https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_2.7.html#using-a-loop-on-a-package-module-via-squash-actions

- remove an unused handler that used an undefined variable, to avoid
  confusion

- make ansible-playbook --check runs not return spurious 'changed'
  results from deficiencies of the pip module:
  https://github.com/ansible/ansible/issues/29895

- add an ansible.cfg that specifies the default inventory file, for
  convenience (you still have to specify username and whether you want
  to use --become on the command line)