### PR TITLE
pycon.lt is moving to vaiduoklis.pov.lt

### DIFF
--- a/websites/pycon.lt/README.rst
+++ b/websites/pycon.lt/README.rst
@@ -1,6 +1,6 @@
 pycon.lt website has been moved to another server, but since email is managed
-by iv-4.pov.lt server, then iv-4.pov.lt still serves pycon.lt domain, just for
-email and redirects all HTTP requests to www.pycon.lt.
+by vaiduoklis.pov.lt server, then vaiduoklis.pov.lt still serves pycon.lt
+domain, just for email and redirects all HTTP requests to www.pycon.lt.
 
 
 How to use

--- a/websites/pycon.lt/ansible.cfg
+++ b/websites/pycon.lt/ansible.cfg
@@ -1,2 +1,5 @@
 [defaults]
 inventory = inventory.cfg
+
+# Use Python 3 for ansible modules
+interpreter_python = auto

--- a/websites/pycon.lt/deploy.yml
+++ b/websites/pycon.lt/deploy.yml
@@ -30,7 +30,11 @@
     register: letsencryptcert
 
   - name: set up apache virtual host
-    template: src=templates/apache.conf.j2 dest=/etc/apache2/sites-enabled/pycon.lt.conf
+    template: src=templates/apache.conf.j2 dest=/etc/apache2/sites-available/pycon.lt.conf
+    notify: reload apache
+
+  - name: enable apache site
+    file: src=../sites-available/pycon.lt.conf dest=/etc/apache2/sites-enabled/pycon.lt.conf state=link
     notify: reload apache
 
   - name: create log dir
@@ -74,7 +78,7 @@
     when: letsencrypt.changed
 
   - name: apache config after letsencrypt
-    template: src=templates/apache.conf.j2 dest=/etc/apache2/sites-enabled/pycon.lt.conf
+    template: src=templates/apache.conf.j2 dest=/etc/apache2/sites-available/pycon.lt.conf
     notify: reload apache
     when: letsencrypt.changed
 

--- a/websites/pycon.lt/inventory.cfg
+++ b/websites/pycon.lt/inventory.cfg
@@ -1,2 +1,2 @@
 [all]
-iv-4.pov.lt
+vaiduoklis.pov.lt


### PR DESCRIPTION
Also I have strong feelings about /etc/apache2/sites-enabled/ containing *symlinks* to files in ../sites-available/.

I'll update the DNS records for **pycon.lt** and **mail.pycon.lt** after the apache config is actually deployed, which I haven't done yet.