### PR TITLE
manopozicija.lt is moving to vaiduoklis.pov.lt

### DIFF
--- a/websites/manopozicija.lt/README.rst
+++ b/websites/manopozicija.lt/README.rst
@@ -21,7 +21,7 @@ instructions bellow helps you to do that.
 Install vagrant, virtualbox and ansible::
 
     sudo apt install vagrant virtualbox python-pip
-    sudo pip install 'ansible>=1.6'
+    sudo pip install ansible
 
 For the vagrant, you will probably need to download it from vagrant.com_,
 because at least 1.6 version is required.

--- a/websites/manopozicija.lt/Vagrantfile
+++ b/websites/manopozicija.lt/Vagrantfile
@@ -2,7 +2,7 @@ Vagrant.require_version ">= 1.6"
 
 Vagrant.configure('2') do |config|
   config.vm.define 'box' do |box|
-    box.vm.box = 'ubuntu/trusty64'
+    box.vm.box = 'ubuntu/focal64'
     box.vm.network :forwarded_port, guest: 80, host: 8080
     box.vm.network :private_network, ip: "10.0.0.42"
     box.vm.synced_folder '.', '/vagrant', disabled: true

--- a/websites/manopozicija.lt/ansible.cfg
+++ b/websites/manopozicija.lt/ansible.cfg
@@ -1,6 +1,9 @@
 [defaults]
 inventory = inventory.cfg
 
+# Use Python 3 for ansible modules
+interpreter_python = auto
+
 # Currently does not work, user --ask-sudo-pass flag
 # https://github.com/ansible/ansible/issues/10891
 become_ask_pass = true

--- a/websites/manopozicija.lt/deploy.yml
+++ b/websites/manopozicija.lt/deploy.yml
@@ -102,7 +102,11 @@
     register: letsencryptcert
 
   - name: set up apache virtual host
-    template: src=templates/apache.conf dest=/etc/apache2/sites-enabled/manopozicija.lt.conf
+    template: src=templates/apache.conf dest=/etc/apache2/sites-available/manopozicija.lt.conf
+    notify: reload apache
+
+  - name: enable apache site
+    file: src=../sites-available/manopozicija.lt.conf dest=/etc/apache2/sites-enabled/manopozicija.lt.conf state=link
     notify: reload apache
 
   - name: create log dir
@@ -146,7 +150,7 @@
     when: letsencrypt.changed
 
   - name: apache config after letsencrypt
-    template: src=templates/apache.conf dest=/etc/apache2/sites-enabled/manopozicija.lt.conf
+    template: src=templates/apache.conf dest=/etc/apache2/sites-available/manopozicija.lt.conf
     notify: reload apache
     when: letsencrypt.changed
 

--- a/websites/manopozicija.lt/deploy.yml
+++ b/websites/manopozicija.lt/deploy.yml
@@ -10,13 +10,13 @@
     env: production
 
   vars_files:
-    - vars/{{ env }}.yml
+  - vars/{{ env }}.yml
 
 
   tasks:
 
-  - fail: msg="Ansible version 1.9 or greater required."
-    when: ansible_version.full | version_compare('1.9', '<')
+  - fail: msg="Ansible version 2.5 or greater required."
+    when: ansible_version.full is version('2.5', '<')
 
   - name: update locale
     locale_gen: name={{ item }} state=present
@@ -28,23 +28,22 @@
     apt_repository: "repo='deb-src http://ubuntu-archive.mirror.serveriai.lt/ {{ ansible_distribution_release }} main restricted universe' state=present"
 
   - name: apt packages
-    apt: pkg={{ item }} state=latest
-    with_items:
-    - build-essential
-    - postgresql
-    - python-psycopg2
-    - python-dev
-    - python-pip
-    - python-virtualenv
-    - apache2
-    - libapache2-mod-wsgi-py3
-    - git
+    apt:
+      name:
+      - build-essential
+      - postgresql
+      - python3-psycopg2
+      - python3-dev
+      - virtualenv
+      - apache2
+      - libapache2-mod-wsgi-py3
+      - git
 
-    # Lets encrypt
-    - libaugeas0
-    - libssl-dev
-    - libffi-dev
-    - ca-certificates
+      # Lets encrypt
+      - libaugeas0
+      - libssl-dev
+      - libffi-dev
+      - ca-certificates
 
   - name: create user
     user: name=manopozicija system=yes group=www-data home={{ home }}
@@ -124,8 +123,8 @@
   - name: install letsencrypt
     pip: name={{ item }} virtualenv=/opt/letsencrypt state=latest
     with_items:
-    - letsencrypt
-    - letsencrypt-apache
+    - certbot
+    - certbot-apache
 
   - name: let's encrypt!
     command: >

--- a/websites/manopozicija.lt/deploy.yml
+++ b/websites/manopozicija.lt/deploy.yml
@@ -158,3 +158,6 @@
 
   - name: reload apache
     service: name=apache2 state=reloaded
+
+  - name: restart apache
+    service: name=apache2 state=restarted

--- a/websites/manopozicija.lt/inventory.cfg
+++ b/websites/manopozicija.lt/inventory.cfg
@@ -1,2 +1,2 @@
 [all]
-iv-4.pov.lt
+vaiduoklis.pov.lt


### PR DESCRIPTION
Also,

* Modern versions of ansible don't understand the 'version_compare()' filter, which was renamed to 'version()' in 2.5, and is a test, not a  filter besides

* Modern versions of ansible emit warnings when you use 'apt' with a loop instead of passing a list to 'name'

* I set the minimum Ansible version to 2.5 although maybe it should be 2.8, which IIRC introduced the interpreter_python = auto setting, which I want to have Ansible use Python 3 by default, for reasons (e.g. python3-apt is installed on vaiduoklis, but python-apt isn't)

* ubuntu/trusty64 is very outdated thanks

* the letsencrypt client was renamed to certbot ages ago

* the 'restart apache' handler was missing

* Apache config files should live in sites-available; sites-enabled should contain symlinks only