### PR TITLE
ubuntu.lt is moving to vaiduoklis.pov.lt

### DIFF
--- a/websites/ubuntu.lt/ansible.cfg
+++ b/websites/ubuntu.lt/ansible.cfg
@@ -1,5 +1,8 @@
 [defaults]
-hostfile = inventory.cfg
+inventory = inventory.cfg
+
+# Use Python 3 for ansible modules
+interpreter_python = auto
 
 # Currently does not work, user --ask-sudo-pass flag
 # https://github.com/ansible/ansible/issues/10891

--- a/websites/ubuntu.lt/deploy.yml
+++ b/websites/ubuntu.lt/deploy.yml
@@ -113,7 +113,11 @@
     register: letsencryptcert
 
   - name: set up apache virtual host
-    template: src=templates/apache.conf dest=/etc/apache2/sites-enabled/{{ server_name }}.conf
+    template: src=templates/apache.conf dest=/etc/apache2/sites-available/{{ server_name }}.conf
+    notify: reload apache
+
+  - name: enable apache site
+    file: src=../sites-available/{{ server_name }}.conf dest=/etc/apache2/sites-enabled/{{ server_name }}.conf state=link
     notify: reload apache
 
   - name: create log dir
@@ -159,7 +163,7 @@
     when: letsencrypt.changed
 
   - name: "let's encrypt: apache config after letsencrypt"
-    template: src=templates/apache.conf dest=/etc/apache2/sites-enabled/{{ server_name }}.conf
+    template: src=templates/apache.conf dest=/etc/apache2/sites-available/{{ server_name }}.conf
     notify: reload apache
     when: letsencrypt.changed
 

--- a/websites/ubuntu.lt/deploy.yml
+++ b/websites/ubuntu.lt/deploy.yml
@@ -5,7 +5,6 @@
 
 
   vars:
-    name: ubuntu.lt
     slug: ubuntult
     home: /opt/ubuntu.lt
     path: "{{ home }}/spirit"
@@ -27,25 +26,25 @@
     apt_repository: "repo='deb-src http://ubuntu-archive.mirror.serveriai.lt/ {{ ansible_distribution_release }} main restricted universe' state=present"
 
   - name: apt packages
-    apt: pkg={{ item }} state=latest
-    with_items:
-    - build-essential
-    - postgresql
-    - python-psycopg2
-    - python-dev
-    - python-pip
-    - python-virtualenv
-    - apache2
-    - libapache2-mod-wsgi-py3
-    - gettext
-    - git
+    apt:
+      name:
+      - build-essential
+      - postgresql
+      - python3-psycopg2
+      - python3-dev
+      - virtualenv
+      - apache2
+      - libapache2-mod-wsgi-py3
+      - gettext
+      - git
 
   - name: apt build dependencies
-    apt: pkg={{ item }} state=build-dep
-    with_items:
-    - python-lxml
-    - python-imaging
-    - python-psycopg2
+    apt:
+      state: build-dep
+      name:
+      - python3-lxml
+      - python3-imaging
+      - python3-psycopg2
 
   - name: create {{ slug }} user
     user: name={{ slug }} system=yes group=www-data home={{ home }}
@@ -72,19 +71,13 @@
     notify: restart gunicorn
     become_user: "{{ slug }}"
 
-  # TODO: How to install pyven (https://github.com/pyenv/pyenv)?
-  #
-  #       git clone https://github.com/pyenv/pyenv.git /opt/pyenv
-  #       export PYENV_ROOT=/opt/pyenv
-  #       export PATH=$PYENV_ROOT/bin:$PATH
-  #       pyenv install 3.8.2
-  - name: install pyenv
+  # TODO: maybe set up deadsnakes PPA if python3.8 is not available on the server
 
   - name: create virtualenv
-    command: virtualenv --python=/opt/pyenv/versions/3.8.5/bin/python {{ home }}/venv chdir={{ path }} creates={{ home }}/venv/bin/python
+    command: virtualenv --python=python3 {{ home }}/venv chdir={{ path }} creates={{ home }}/venv/bin/python
     become_user: "{{ slug }}"
 
-  - name: install project depencencies from requirements.txt
+  - name: install project dependencies from requirements.txt
     command: "{{ home }}/venv/bin/pip install -r requirements.txt chdir={{ path }}"
     become_user: "{{ slug }}"
 
@@ -132,18 +125,18 @@
   # Let's Encrypt
 
   - name: "let's encrypt: apt packages"
-    apt: pkg={{ item }} state=latest
-    with_items:
-    - libaugeas0
-    - libssl-dev
-    - libffi-dev
-    - ca-certificates
+    apt:
+      name:
+      - libaugeas0
+      - libssl-dev
+      - libffi-dev
+      - ca-certificates
 
   - name: "let's encrypt: pip packages"
     pip: name={{ item }} virtualenv=/opt/letsencrypt state=latest
     with_items:
-    - letsencrypt
-    - letsencrypt-apache
+    - certbot
+    - certbot-apache
 
   - name: "let's encrypt!"
     command: >

--- a/websites/ubuntu.lt/inventory.cfg
+++ b/websites/ubuntu.lt/inventory.cfg
@@ -1,2 +1,2 @@
 [all]
-iv-4.pov.lt
+vaiduoklis.pov.lt


### PR DESCRIPTION
Also

* The inventory file is specified in ansible.cfg by using 'inventory', not 'hostfile'

* Ask for Python 3 by default on the target via interpreter_python = auto

* Fix warning about using reserved variable name 'name' (the variable was unused)

* Pass lists to apt module instead of looping

* Use Python 3 versions of dependencies (e.g. python-psycopg2 doesn't even exist in Ubuntu 20.04 LTS, but python3-psycopg2 does)

* Python 3.8 is already available in Ubuntu 20.04 LTS, so drop the unfinished pyenv bits (and suggest deadsnakes instead, in case it ever becomes necessary to use a Python 3 version not shipped by Ubuntu)

* There was a typo in a task description

* The letsencrypt client was renamed to certbot long ago

* Apache config files should live in sites-available; sites-enabled should contain symlinks only
